### PR TITLE
fix/HTTP request get and head 

### DIFF
--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -185,7 +185,7 @@ type Client struct {
 }
 
 func checkParameterListSize(methodType string, vu modules.VU, args ...goja.Value){
-	if len(args) > 1{
+	if len(args) > 1 {
 		vu.State().Logger.Warningf("%s method has more than two arguments", methodType)
 	}
 }

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -69,18 +69,14 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	// wrappers (facades) that convert the old k6 idiosyncratic APIs to the new
 	// proper Client ones that accept Request objects and don't suck
 	mustExport("get", func(url goja.Value, args ...goja.Value) (*Response, error) {
-		if checkQuantityParameter(args...) {
-			vu.State().Logger.Warningf("GET method has more than two arguments")
-		}
+		checkParameterListSize("get",vu, args...)
 		// http.get(url, params) doesn't have a body argument, so we add undefined
 		// as the third argument to http.request(method, url, body, params)
 		args = append([]goja.Value{goja.Undefined()}, args...)
 		return mi.defaultClient.Request(http.MethodGet, url, args...)
 	})
 	mustExport("head", func(url goja.Value, args ...goja.Value) (*Response, error) {
-		if checkQuantityParameter(args...) {
-			vu.State().Logger.Warningf("Head method has more than two arguments")
-		}
+		checkParameterListSize("head",vu, args...) 
 		// http.head(url, params) doesn't have a body argument, so we add undefined
 		// as the third argument to http.request(method, url, body, params)
 		args = append([]goja.Value{goja.Undefined()}, args...)
@@ -188,11 +184,8 @@ type Client struct {
 	responseCallback func(int) bool
 }
 
-func checkQuantityParameter(args ...goja.Value) bool {
-	for i := range args {
-		if i >= 1 {
-			return true
-		}
+func checkParameterListSize(methodType string, vu modules.VU, args ...goja.Value){
+	if len(args) > 1{
+		vu.State().Logger.Warningf("%s method has more than two arguments", methodType)
 	}
-	return false
 }


### PR DESCRIPTION
## What?
The following PR aims to solve the problem mentioned in the issue [2823](https://github.com/grafana/k6/issues/2823)

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x ] I have performed a self-review of my code.
- [x ] I have run linter locally (`make lint`) and all checks pass.
- [x ] I have commented on my code, particularly in hard-to-understand areas.

## Steps to reproduce the problem
```
import http from "k6/http";
import { check } from "k6";

export default () => {
  const params = {
    headers: {
      "oi": "ola",
    },
  };

  const res = http.get("http://localhost:3000/",null,params);
  check(res, {
    "status is 200": (r) => r.status === 200,
  });
};
```